### PR TITLE
changed module export for OptionResult to OptionsResult for consistency

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -326,5 +326,5 @@ class Runner {
 module.exports = {
   Runner,
   TextResult: results.TextResult,
-  OptionResult: results.OptionsResult,
+  OptionsResult: results.OptionsResult,
 };


### PR DESCRIPTION
Since the fix for #28 is super simple, I just went ahead and added an 's' to `OptionResult` in the `runner.js` file.