### PR TITLE
ability to call JS functions in yarn. Example <<console.log("Test JS")>> via a new jsEvalResult node

### DIFF
--- a/src/parser/nodes.js
+++ b/src/parser/nodes.js
@@ -120,7 +120,8 @@ module.exports = {
     constructor(numericLiteral) {
       super();
       this.type = 'NumericLiteralNode';
-      this.numericLiteral = numericLiteral;
+      this.numericLiteral = numericLiteral; /// kept for compatibility
+      this.value = eval(numericLiteral); /// added for consistency between Node's datastructure.. Is called .value in all
     }
   },
 
@@ -129,6 +130,7 @@ module.exports = {
       super();
       this.type = 'StringLiteralNode';
       this.stringLiteral = stringLiteral;
+      this.value = stringLiteral;
     }
   },
 
@@ -137,6 +139,7 @@ module.exports = {
       super();
       this.type = 'BooleanLiteralNode';
       this.booleanLiteral = booleanLiteral;
+      this.value = eval(booleanLiteral);
     }
   },
 
@@ -145,6 +148,7 @@ module.exports = {
       super();
       this.type = 'VariableNode';
       this.variableName = variableName;
+      this.value = variableName;
     }
   },
 
@@ -352,6 +356,15 @@ module.exports = {
     constructor(functionName, args) {
       super();
       this.type = 'FunctionResultNode';
+      this.functionName = functionName;
+      this.args = args;
+    }
+  },
+  
+  jsEvalNode: class extends Literal {
+    constructor(functionName, args) {
+      super();
+      this.type = 'jsEvalNode';
       this.functionName = functionName;
       this.args = args;
     }

--- a/src/parser/nodes.js
+++ b/src/parser/nodes.js
@@ -130,7 +130,7 @@ module.exports = {
       super();
       this.type = 'StringLiteralNode';
       this.stringLiteral = stringLiteral;
-      this.value = stringLiteral;
+      this.value = '"' + stringLiteral + '"';
     }
   },
 
@@ -367,6 +367,15 @@ module.exports = {
       this.type = 'jsEvalNode';
       this.functionName = functionName;
       this.args = args;
+      if (args.length === 0){
+        this.evalString = functionName + "()";
+      }else{
+        this.evalString = functionName + "("
+        args.forEach((parameter,i) => {
+          this.evalString += String(parameter.value);
+          if (i < args.length-1){ this.evalString += ","}
+        });this.evalString += ");"
+      }
     }
   },
 

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -114,6 +114,10 @@ const grammar = {
       // Extremely ugly hack because a command with spaces (e.g. <<foo bar>>)
       // Lexes as BeginCommand Identifier Text EndCommand
       ['BeginCommand Identifier Text EndCommand', '$$ = new yy.CommandNode($2 + " " + $3);'],
+
+      //// This enables the ability to run pure JS
+      ['BeginCommand Identifier LeftParen RightParen EndCommand', '$$ = new yy.jsEvalNode($2);'], /// <<myfunction()>>
+      ['BeginCommand Identifier LeftParen arguments RightParen EndCommand', '$$ = new yy.jsEvalNode($2,$4);'], /// <<myfunction(\"test\",True,22)>>
     ],
 
     arguments: [
@@ -124,6 +128,8 @@ const grammar = {
     argument: [
       ['Number', '$$ = new yy.NumericLiteralNode($1);'],
       ['String', '$$ = new yy.StringLiteralNode($1);'],
+      ['True', '$$ = new yy.BooleanLiteralNode($1);'],
+      ['False', '$$ = new yy.BooleanLiteralNode($1);'],
       ['Variable', '$$ = new yy.VariableNode($1.substring(1));'],
     ],
   },

--- a/src/results.js
+++ b/src/results.js
@@ -22,6 +22,7 @@ class jsEvalResult extends Result { ///NEW
     super();
     this.functionName = node.functionName;
     this.args = node.args;
+    this.evalString = node.evalString;
   }
 }
 

--- a/src/results.js
+++ b/src/results.js
@@ -13,14 +13,15 @@ class TextResult extends Result {
   }
 }
 
-class CommandResult extends Result { ///NEW
+class jsEvalResult extends Result { ///NEW
   /**
    * Return commands in the node
-   * @param {string} [command] return commands from node
+   * @param {any[]} [node] array of text to be displayed
    */
-  constructor(command) {
+  constructor(node) {
     super();
-    this.command = command;
+    this.functionName = node.functionName;
+    this.args = node.args;
   }
 }
 
@@ -43,4 +44,4 @@ class OptionsResult extends Result {
   }
 }
 
-module.exports = { Result, TextResult, OptionsResult,  CommandResult};
+module.exports = { Result, TextResult, OptionsResult,  jsEvalResult};

--- a/src/results.js
+++ b/src/results.js
@@ -16,7 +16,7 @@ class TextResult extends Result {
 class CommandResult extends Result { ///NEW
   /**
    * Return commands in the node
-   * @param {string} [command] array of text to be displayed
+   * @param {string} [command] return commands from node
    */
   constructor(command) {
     super();

--- a/src/results.js
+++ b/src/results.js
@@ -13,6 +13,17 @@ class TextResult extends Result {
   }
 }
 
+class CommandResult extends Result { ///NEW
+  /**
+   * Return commands in the node
+   * @param {string} [command] array of text to be displayed
+   */
+  constructor(command) {
+    super();
+    this.command = command;
+  }
+}
+
 class OptionsResult extends Result {
   /**
    * Create a selectable list of options from the given list of text
@@ -32,4 +43,4 @@ class OptionsResult extends Result {
   }
 }
 
-module.exports = { Result, TextResult, OptionsResult };
+module.exports = { Result, TextResult, OptionsResult,  CommandResult};

--- a/src/runner.js
+++ b/src/runner.js
@@ -137,6 +137,7 @@ class Runner {
             // Special command, halt execution
             return;
           }
+          yield new results.CommandResult(node.command);
 
           if (this.commandHandler) {
             this.commandHandler(node.command);
@@ -176,7 +177,6 @@ class Runner {
       const optionResults = new results.OptionsResult(filteredSelections.map((s) => {
         return s.text;
       }));
-
       yield optionResults;
 
       if (optionResults.selected !== -1) {
@@ -327,4 +327,5 @@ module.exports = {
   Runner,
   TextResult: results.TextResult,
   OptionsResult: results.OptionsResult,
+  CommandResult: results.CommandResult
 };

--- a/src/runner.js
+++ b/src/runner.js
@@ -333,5 +333,5 @@ module.exports = {
   Runner,
   TextResult: results.TextResult,
   OptionsResult: results.OptionsResult,
-  CommandResult: results.CommandResult
+  jsEvalResult: results.jsEvalResult
 };

--- a/src/runner.js
+++ b/src/runner.js
@@ -72,13 +72,13 @@ class Runner {
   */
   * run(startNode) {
     const yarnNode = this.yarnNodes[startNode];
-
+    
     if (yarnNode === undefined) {
       throw new Error(`Node "${startNode}" does not exist`);
     }
-
+    
     this.visited[startNode] = true;
-
+    
     // Parse the entire node
     const parserNodes = Array.from(parser.parse(yarnNode.body));
     yield* this.evalNodes(parserNodes);
@@ -137,11 +137,17 @@ class Runner {
             // Special command, halt execution
             return;
           }
-          yield new results.CommandResult(node.command);
+          
+          // yield new results.CommandResult(node.command);
 
           if (this.commandHandler) {
             this.commandHandler(node.command);
           }
+        }
+        
+        else if (node.type == "jsEvalNode"){
+          yield new results.jsEvalResult(node);
+          console.log(node)
         }
       }
     }
@@ -308,7 +314,7 @@ class Runner {
         return node.booleanLiteral === 'true';
       } else if (node.type === 'VariableNode') {
         return this.variables.get(node.variableName);
-      } else if (node.type === 'FunctionResultNode') {
+      } else if (node.type === 'FunctionResultNode') {  
         if (this.functions[node.functionName]) {
           return this.functions[node.functionName](node.args.map(this.evaluateExpressionOrLiteral));
         }


### PR DESCRIPTION
With this pull it is possible to do this in yarn:
`<<console.log("Test JS")>>`

and use it like this in your app via bondage.js:
```
	if (result instanceof bondage.jsEvalResult) {
		eval(result.evalString) //--> prints out 'Test JS'
	}
```
Its not directly triggered by bondage.js, so you still need to register it- but now it is possible at least, without having to register individual commands manually - making bondage.js a bit more flexible with less code

I just implemented it in the least intrusive way I could figure out. Anyways, I hope it helps others who may need it 

It also adds some things: 
- JsEvalNode type that can return the function name,parameters in their right value type and an easy to use evalString that can be passed like this: `eval(result.evalString) ` in project using bondage.js
- ability to pass boolean parameters (was missing in the parser for some reason), 
- consistent generic path and correct value type on LiteralNodes for easier integration of bondage with other projects (node.value= value is available on all literal nodes)
- support for <<test(parameters)>> and <<test()>> in parser.js - so bondage shouldnt crash the application when that is in the body of a Yarn node