### PR TITLE
fix  <<command()>>  and  <<command("parameters")>> crashing bondage.js

### DIFF
--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -114,6 +114,8 @@ const grammar = {
       // Extremely ugly hack because a command with spaces (e.g. <<foo bar>>)
       // Lexes as BeginCommand Identifier Text EndCommand
       ['BeginCommand Identifier Text EndCommand', '$$ = new yy.CommandNode($2 + " " + $3);'],
+      ['BeginCommand Identifier LeftParen RightParen EndCommand', '$$ = new yy.CommandNode($2 + "()");'], /// <<myfunction()>>
+      ['BeginCommand Identifier LeftParen arguments RightParen EndCommand', '$$ = new yy.CommandNode($2 + "()");'], /// <<myfunction("test",True,22)>>
     ],
 
     arguments: [
@@ -125,6 +127,8 @@ const grammar = {
       ['Number', '$$ = new yy.NumericLiteralNode($1);'],
       ['String', '$$ = new yy.StringLiteralNode($1);'],
       ['Variable', '$$ = new yy.VariableNode($1.substring(1));'],
+      ['True', '$$ = new yy.BooleanLiteralNode($1);'],
+      ['False', '$$ = new yy.BooleanLiteralNode($1);'],
     ],
   },
 };

--- a/tests/test_parser.js
+++ b/tests/test_parser.js
@@ -171,4 +171,92 @@ describe('Parser', () => {
 
     expect(results).to.deep.equal(expected);
   });
+
+  it('can pass commands with myCommand() formatting - can parse some text followed a command', () => {
+    const results = parser.parse('some text<<commandtext()>>');
+
+    const expected = [
+      new nodes.TextNode('some text'),
+      new nodes.CommandNode('commandtext()'),
+    ];
+
+    expect(results).to.deep.equal(expected);
+  });
+
+  it('can pass commands with myCommand() formatting - can parse some text followed by a newline and a command', () => {
+    const results = parser.parse('some text\n<<commandtext()>>');
+
+    const expected = [
+      new nodes.TextNode('some text'),
+      new nodes.CommandNode('commandtext()'),
+    ];
+
+    expect(results).to.deep.equal(expected);
+  });
+
+  it('can pass commands with myCommand() formatting - correctly ignores a double newline', () => {
+    const results = parser.parse('some text\n\n<<commandtext()>>');
+
+    const expected = [
+      new nodes.TextNode('some text'),
+      new nodes.CommandNode('commandtext()'),
+    ];
+
+    expect(results).to.deep.equal(expected);
+  });
+
+  it('can pass commands with myCommand() formatting - correctly ignores a bunch of newlines', () => {
+    const results = parser.parse('some text\n\n\n\n\n\n<<commandtext()>>\n');
+
+    const expected = [
+      new nodes.TextNode('some text'),
+      new nodes.CommandNode('commandtext()'),
+    ];
+
+    expect(results).to.deep.equal(expected);
+  });
+
+  it('can pass commands with myCommand("test",True,22) formatting - can parse some text followed a command', () => {
+    const results = parser.parse('some text<<commandtext("test",True,22)>>');
+
+    const expected = [
+      new nodes.TextNode('some text'),
+      new nodes.CommandNode('commandtext()'), // will also add parameter parsing when this pull gets approved. Command node needs refactoring to support it
+    ];
+
+    expect(results).to.deep.equal(expected);
+  });
+
+  it('can pass commands with myCommand("test",True,22) formatting - can parse some text followed by a newline and a command', () => {
+    const results = parser.parse('some text\n<<commandtext("test",True,22)>>');
+
+    const expected = [
+      new nodes.TextNode('some text'),
+      new nodes.CommandNode('commandtext()'), // will also add parameter parsing when this pull gets approved. Command node needs refactoring to support it
+    ];
+
+    expect(results).to.deep.equal(expected);
+  });
+
+  it('can pass commands with myCommand("test",True,22) formatting - correctly ignores a double newline', () => {
+    const results = parser.parse('some text\n\n<<commandtext("test",True,22)>>');
+
+    const expected = [
+      new nodes.TextNode('some text'),
+      new nodes.CommandNode('commandtext()'), // will also add parameter parsing when this pull gets approved. Command node needs refactoring to support it
+    ];
+
+    expect(results).to.deep.equal(expected);
+  });
+
+  it('can pass commands with myCommand("test",True,22)formatting - correctly ignores a bunch of newlines', () => {
+    const results = parser.parse('some text\n\n\n\n\n\n<<commandtext("test",True,22)>>\n');
+
+    const expected = [
+      new nodes.TextNode('some text'),
+      new nodes.CommandNode('commandtext()'), // will also add parameter parsing when this pull gets approved. Command node needs refactoring to support it
+    ];
+
+    expect(results).to.deep.equal(expected);
+  });
 });


### PR DESCRIPTION
This stops commands with js-esque syntax  from crashing bondage.js 

It also adds additional tests to bondage.js to make sure the syntax is not crashing it.
The parameters in () dont get passed yet - as it would require some refactoring of nodes.js which was requested to be done in another pull.