### PR TITLE
allow access to node data of yarn nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Yarn parser for Javascript",
   "main": "src/bondage.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha tests --recursive",
+    "test": "node node_modules/mocha/bin/mocha tests --recursive",
     "lint": "node_modules/.bin/eslint ."
   },
   "bin": {

--- a/src/results.js
+++ b/src/results.js
@@ -7,7 +7,7 @@ class TextResult extends Result {
    * Create a text display result
    * @param {string} [text] text to be displayed
    */
-  constructor(text,yarnNodeData) {
+  constructor(text, yarnNodeData) {
     super();
     this.text = text;
     this.data = yarnNodeData;

--- a/src/results.js
+++ b/src/results.js
@@ -7,9 +7,10 @@ class TextResult extends Result {
    * Create a text display result
    * @param {string} [text] text to be displayed
    */
-  constructor(text) {
+  constructor(text,yarnNodeData) {
     super();
     this.text = text;
+    this.data = yarnNodeData;
   }
 }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -87,7 +87,7 @@ class Runner {
       tags:yarnNode.tags.split(" "),
       body:yarnNode.body,
     }
-    yield* this.evalNodes(parserNodes,yarnNodeData);
+    yield* this.evalNodes(parserNodes, yarnNodeData);
   }
 
   /**
@@ -95,7 +95,7 @@ class Runner {
    * the user. Calls itself recursively if that is required by nested nodes
    * @param {any[]} nodes
    */
-  * evalNodes(nodes,yarnNodeData) {
+  * evalNodes(nodes, yarnNodeData) {
     if (!nodes) return;
 
     let selectableNodes = null;
@@ -124,7 +124,7 @@ class Runner {
 
         if (node instanceof nodeTypes.Text) {
           // Just text to be returned
-          yield new results.TextResult(node.text,yarnNodeData);
+          yield new results.TextResult(node.text, yarnNodeData);
         } else if (node instanceof nodeTypes.Link) {
           // Start accumulating link nodes
           selectionType = nodeTypes.Link;

--- a/src/runner.js
+++ b/src/runner.js
@@ -25,6 +25,7 @@ class Runner {
   load(data) {
     for (const node of data) {
       this.yarnNodes[node.title] = {
+        title: node.title,
         tags: node.tags,
         body: node.body,
       };
@@ -81,7 +82,12 @@ class Runner {
 
     // Parse the entire node
     const parserNodes = Array.from(parser.parse(yarnNode.body));
-    yield* this.evalNodes(parserNodes);
+    const yarnNodeData = {
+      title:yarnNode.title,
+      tags:yarnNode.tags.split(" "),
+      body:yarnNode.body,
+    }
+    yield* this.evalNodes(parserNodes,yarnNodeData);
   }
 
   /**
@@ -89,7 +95,7 @@ class Runner {
    * the user. Calls itself recursively if that is required by nested nodes
    * @param {any[]} nodes
    */
-  * evalNodes(nodes) {
+  * evalNodes(nodes,yarnNodeData) {
     if (!nodes) return;
 
     let selectableNodes = null;
@@ -118,7 +124,7 @@ class Runner {
 
         if (node instanceof nodeTypes.Text) {
           // Just text to be returned
-          yield new results.TextResult(node.text);
+          yield new results.TextResult(node.text,yarnNodeData);
         } else if (node instanceof nodeTypes.Link) {
           // Start accumulating link nodes
           selectionType = nodeTypes.Link;

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -34,7 +34,8 @@ describe('Dialogue', () => {
     runner.load(linksYarnData);
     const run = runner.run('OneNode');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is a test line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is a test line', value.data));
     expect(run.next().done).to.be.true;
   });
 
@@ -42,22 +43,26 @@ describe('Dialogue', () => {
     runner.load(linksYarnData);
     const run = runner.run('Option2');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is Option2\'s test line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is Option2\'s test line', value.data));
     expect(run.next().done).to.be.true;
   });
 
   it('Can run through a link to another node', () => {
     runner.load(linksYarnData);
     const run = runner.run('ThreeNodes');
-
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is a test line'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is another test line'));
+    
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is a test line', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is another test line', value.data));
 
     const optionResult = run.next().value;
     expect(optionResult).to.deep.equal(new bondage.OptionsResult(['Option1', 'Option2']));
 
     optionResult.select(0);
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is Option1\'s test line'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is Option1\'s test line', value.data));
 
     expect(run.next().done).to.be.true;
   });
@@ -66,14 +71,17 @@ describe('Dialogue', () => {
     runner.load(linksYarnData);
     const run = runner.run('NamedLink');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is a test line'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is another test line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is a test line', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is another test line', value.data));
 
     const optionResult = run.next().value;
     expect(optionResult).to.deep.equal(new bondage.OptionsResult(['First choice', 'Second choice']));
 
     optionResult.select(1);
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is Option2\'s test line'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is Option2\'s test line', value.data));
 
     expect(run.next().done).to.be.true;
   });
@@ -82,8 +90,10 @@ describe('Dialogue', () => {
     runner.load(linksYarnData);
     const run = runner.run('OneLinkPassthrough');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('First test line'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is Option1\'s test line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('First test line', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is Option1\'s test line', value.data));
     expect(run.next().done).to.be.true;
   });
 
@@ -91,19 +101,22 @@ describe('Dialogue', () => {
     runner.load(linksYarnData);
     const run = runner.run('LinkAfterShortcuts');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('First test line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('First test line', value.data));
 
     let optionResult = run.next().value;
     expect(optionResult).to.deep.equal(new bondage.OptionsResult(['Shortcut 1', 'Shortcut 2']));
 
     optionResult.select(1);
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is the second shortcut'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is the second shortcut', value.data));
 
     optionResult = run.next().value;
     expect(optionResult).to.deep.equal(new bondage.OptionsResult(['First link', 'Second link']));
 
     optionResult.select(0);
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is Option1\'s test line'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is Option1\'s test line', value.data));
 
     expect(run.next().done).to.be.true;
   });
@@ -112,15 +125,17 @@ describe('Dialogue', () => {
     runner.load(shortcutsYarnData);
     const run = runner.run('NonNested');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is a test line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is a test line', value.data));
 
     const optionResult = run.next().value;
     expect(optionResult).to.deep.equal(new bondage.OptionsResult(['Option 1', 'Option 2']));
 
     optionResult.select(1);
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is the second option'));
-
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is after both options'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is the second option', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is after both options', value.data));
     expect(run.next().done).to.be.true;
   });
 
@@ -128,21 +143,24 @@ describe('Dialogue', () => {
     runner.load(shortcutsYarnData);
     const run = runner.run('Nested');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('text'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('text', value.data));
 
     let optionResult = run.next().value;
     expect(optionResult).to.deep.equal(new bondage.OptionsResult(['shortcut1', 'shortcut2']));
 
     optionResult.select(0);
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text1'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text1', value.data));
 
     optionResult = run.next().value;
     expect(optionResult).to.deep.equal(new bondage.OptionsResult(['nestedshortcut1', 'nestedshortcut2']));
 
     optionResult.select(1);
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('NestedText2'));
-
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('more text'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('NestedText2', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('more text', value.data));
     expect(run.next().done).to.be.true;
   });
 
@@ -150,15 +168,17 @@ describe('Dialogue', () => {
     runner.load(shortcutsYarnData);
     const run = runner.run('Conditional');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is a test line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is a test line', value.data));
 
     const optionResult = run.next().value;
     expect(optionResult).to.deep.equal(new bondage.OptionsResult(['Option 1', 'Option 3']));
 
     optionResult.select(1);
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is the third option'));
-
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This is after both options'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is the third option', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This is after both options', value.data));
     expect(run.next().done).to.be.true;
   });
 
@@ -166,11 +186,13 @@ describe('Dialogue', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('Numeric');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data));
 
     expect(runner.variables.get('testvar')).to.be.undefined;
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line After'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data));
 
     expect(runner.variables.get('testvar')).to.equal(-123.4);
 
@@ -181,11 +203,13 @@ describe('Dialogue', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('NumericExpression');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data));
 
     expect(runner.variables.get('testvar')).to.be.undefined;
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line After'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data));
 
     expect(runner.variables.get('testvar')).to.equal(((1 + 2) * -3) + 4.3);
 
@@ -196,11 +220,13 @@ describe('Dialogue', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('String');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data));
 
     expect(runner.variables.get('testvar')).to.be.undefined;
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line After'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data));
 
     expect(runner.variables.get('testvar')).to.equal('Variable String');
 
@@ -211,11 +237,13 @@ describe('Dialogue', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('StringExpression');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data));
 
     expect(runner.variables.get('testvar')).to.be.undefined;
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line After'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data));
 
     expect(runner.variables.get('testvar')).to.equal('Variable String Appended');
 
@@ -226,11 +254,13 @@ describe('Dialogue', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('Boolean');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data));
 
     expect(runner.variables.get('testvar')).to.be.undefined;
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line After'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data));
 
     expect(runner.variables.get('testvar')).to.equal(true);
 
@@ -241,11 +271,13 @@ describe('Dialogue', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('BooleanExpression');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data));
 
     expect(runner.variables.get('testvar')).to.be.undefined;
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line After'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data));
 
     expect(runner.variables.get('testvar')).to.equal(true);
 
@@ -256,12 +288,14 @@ describe('Dialogue', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('Variable');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data));
 
     expect(runner.variables.get('firstvar')).to.be.undefined;
     expect(runner.variables.get('secondvar')).to.be.undefined;
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line After'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data));
 
     expect(runner.variables.get('secondvar')).to.equal('First variable string');
 
@@ -272,12 +306,14 @@ describe('Dialogue', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('VariableExpression');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data));
 
     expect(runner.variables.get('firstvar')).to.be.undefined;
     expect(runner.variables.get('secondvar')).to.be.undefined;
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Test Line After'));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data));
 
     expect(runner.variables.get('secondvar')).to.equal(-4.3 + 100);
 
@@ -288,9 +324,12 @@ describe('Dialogue', () => {
     runner.load(conditionalYarnData);
     const run = runner.run('BasicIf');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text before'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Inside if'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text after'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text before', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Inside if', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text after', value.data));
 
     expect(run.next().done).to.be.true;
   });
@@ -299,9 +338,12 @@ describe('Dialogue', () => {
     runner.load(conditionalYarnData);
     const run = runner.run('BasicIfElse');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text before'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Inside else'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text after'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text before', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Inside else', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text after', value.data));
 
     expect(run.next().done).to.be.true;
   });
@@ -310,9 +352,12 @@ describe('Dialogue', () => {
     runner.load(conditionalYarnData);
     const run = runner.run('BasicIfElseIf');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text before'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Inside elseif'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text after'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text before', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Inside elseif', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text after', value.data));
 
     expect(run.next().done).to.be.true;
   });
@@ -321,9 +366,12 @@ describe('Dialogue', () => {
     runner.load(conditionalYarnData);
     const run = runner.run('BasicIfElseIfElse');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text before'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Inside else'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Text after'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text before', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Inside else', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Text after', value.data));
 
     expect(run.next().done).to.be.true;
   });
@@ -332,7 +380,8 @@ describe('Dialogue', () => {
     runner.load(commandAndFunctionYarnData);
     const run = runner.run('StopCommand');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('First line'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('First line', value.data));
     expect(run.next().done).to.be.true;
   });
 
@@ -345,7 +394,8 @@ describe('Dialogue', () => {
       lastCommand = command;
     });
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('text in between commands'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('text in between commands', value.data));
     expect(lastCommand).to.equal('command1');
 
     expect(run.next().done).to.be.true;
@@ -369,9 +419,12 @@ describe('Dialogue', () => {
       throw new Error(`Args ${args} were not expected in testfunc`);
     });
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('First line'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('This should show'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('After both'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('First line', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('This should show', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('After both', value.data));
 
     expect(run.next().done).to.be.true;
   });
@@ -380,8 +433,10 @@ describe('Dialogue', () => {
     runner.load(commandAndFunctionYarnData);
     const run = runner.run('VisitedFunctionStart');
 
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('Hello'));
-    expect(run.next().value).to.deep.equal(new bondage.TextResult('you have visited VisitedFunctionStart!'));
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Hello', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('you have visited VisitedFunctionStart!', value.data));
 
     expect(run.next().done).to.be.true;
   });


### PR DESCRIPTION
This allows access to the node's tags, title and even raw body- of textResult nodes. The idea is that this information can be evaluated when changing to a new text scroll

My ultimate goal is to be able to use the tags to change dialogue avatars and to trigger other things- whenever the text box is starting to redraw