### PR TITLE
Prevent <<command("parameters",123)>> from crashing bondage.js

### DIFF
--- a/src/lexer/states.js
+++ b/src/lexer/states.js
@@ -22,7 +22,7 @@ function makeStates() {
                              .addTransition('EndIf')
                              .addTransition('Set', 'assignment')
                              .addTransition('EndCommand', 'base', true)
-                             .addTransition('Identifier', 'commandOrExpression')
+                             .addTransition('CmdIdentifier', 'commandOrExpression')
                              .addTransition('Text', 'commandOrExpression')
                              .addTextRule('Text'),
 

--- a/src/lexer/states.js
+++ b/src/lexer/states.js
@@ -22,8 +22,7 @@ function makeStates() {
                              .addTransition('EndIf')
                              .addTransition('Set', 'assignment')
                              .addTransition('EndCommand', 'base', true)
-                             .addTransition('CmdIdentifier', 'commandOrExpression')
-                             .addTransition('Text', 'commandOrExpression')
+                             .addTransition('CommandCall', 'commandOrExpression')
                              .addTextRule('Text'),
 
     commandOrExpression: new LexerState().addTransition('EndCommand', 'base', true)

--- a/src/lexer/states.js
+++ b/src/lexer/states.js
@@ -23,12 +23,8 @@ function makeStates() {
                              .addTransition('Set', 'assignment')
                              .addTransition('EndCommand', 'base', true)
                              .addTransition('Identifier', 'commandOrExpression')
-                             .addTransition('CmdIdentifier', 'commandOrExpression')
+                             .addTransition('Text', 'commandOrExpression')
                              .addTextRule('Text'),
-
-    // commandOrExpression: new LexerState().addTransition('LeftParen', 'expression')
-    //                          .addTransition('EndCommand', 'base', true)
-    //                          .addTextRule('Text'),  
 
     commandOrExpression: new LexerState().addTransition('EndCommand', 'base', true)
                                          .addTextRule('Text'),

--- a/src/lexer/states.js
+++ b/src/lexer/states.js
@@ -23,10 +23,14 @@ function makeStates() {
                              .addTransition('Set', 'assignment')
                              .addTransition('EndCommand', 'base', true)
                              .addTransition('Identifier', 'commandOrExpression')
+                             .addTransition('CmdIdentifier', 'commandOrExpression')
                              .addTextRule('Text'),
 
-    commandOrExpression: new LexerState().addTransition('LeftParen', 'expression')
-                                         .addTransition('EndCommand', 'base', true)
+    // commandOrExpression: new LexerState().addTransition('LeftParen', 'expression')
+    //                          .addTransition('EndCommand', 'base', true)
+    //                          .addTextRule('Text'),  
+
+    commandOrExpression: new LexerState().addTransition('EndCommand', 'base', true)
                                          .addTextRule('Text'),
 
     assignment: new LexerState().addTransition('Variable')

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -89,8 +89,6 @@ const Tokens = {
 
   Identifier:           /[a-zA-Z0-9_:.]+/,         // a single word (used for functions)
 
-  // CmdIdentifier:           /['";()\[\]\/a-zA-Z0-9_:.]+/,         // a single word (used for functions) with extra symbols
-
   Text:                 /.*/,                      // a run of text until we hit other syntax.
 };
 /* eslint-enable key-spacing */

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -89,6 +89,8 @@ const Tokens = {
 
   Identifier:           /[a-zA-Z0-9_:.]+/,         // a single word (used for functions)
 
+  CmdIdentifier:        /[\"\'\+\=a-zA-Z0-9_:.,()]+/,  // a single word (used for commands)
+
   Text:                 /.*/,                      // a run of text until we hit other syntax.
 };
 /* eslint-enable key-spacing */

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -89,6 +89,8 @@ const Tokens = {
 
   Identifier:           /[a-zA-Z0-9_:.]+/,         // a single word (used for functions)
 
+  CmdIdentifier:           /['";()\[\]\/a-zA-Z0-9_:.]+/,         // a single word (used for functions) with extra symbols
+
   Text:                 /.*/,                      // a run of text until we hit other syntax.
 };
 /* eslint-enable key-spacing */

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -89,7 +89,7 @@ const Tokens = {
 
   Identifier:           /[a-zA-Z0-9_:.]+/,         // a single word (used for functions)
 
-  CmdIdentifier:           /['";()\[\]\/a-zA-Z0-9_:.]+/,         // a single word (used for functions) with extra symbols
+  // CmdIdentifier:           /['";()\[\]\/a-zA-Z0-9_:.]+/,         // a single word (used for functions) with extra symbols
 
   Text:                 /.*/,                      // a run of text until we hit other syntax.
 };

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -89,7 +89,7 @@ const Tokens = {
 
   Identifier:           /[a-zA-Z0-9_:.]+/,         // a single word (used for functions)
 
-  CmdIdentifier:        /["'+-=\[\]\*a-zA-Z0-9_:;{}&|.,()]+/,  // a single word (used for commands)
+  CommandCall:          /([^>]|(?!>)[^>]+>)+(?=>>)/,// Command call
 
   Text:                 /.*/,                      // a run of text until we hit other syntax.
 };

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -89,7 +89,7 @@ const Tokens = {
 
   Identifier:           /[a-zA-Z0-9_:.]+/,         // a single word (used for functions)
 
-  CmdIdentifier:        /["'+=\[\]a-zA-Z0-9_:.,()]+/,  // a single word (used for commands)
+  CmdIdentifier:        /["'+-=\[\]\*a-zA-Z0-9_:;{}&|.,()]+/,  // a single word (used for commands)
 
   Text:                 /.*/,                      // a run of text until we hit other syntax.
 };

--- a/src/lexer/tokens.js
+++ b/src/lexer/tokens.js
@@ -89,7 +89,7 @@ const Tokens = {
 
   Identifier:           /[a-zA-Z0-9_:.]+/,         // a single word (used for functions)
 
-  CmdIdentifier:        /[\"\'\+\=a-zA-Z0-9_:.,()]+/,  // a single word (used for commands)
+  CmdIdentifier:        /["'+=\[\]a-zA-Z0-9_:.,()]+/,  // a single word (used for commands)
 
   Text:                 /.*/,                      // a run of text until we hit other syntax.
 };

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -109,11 +109,11 @@ const grammar = {
     ],
 
     command: [
-      ['BeginCommand Identifier EndCommand', '$$ = new yy.CommandNode($2);'],
       ['BeginCommand CmdIdentifier EndCommand', '$$ = new yy.CommandNode($2);'],
       /// Extremely ugly hack because a command with spaces (e.g. <<foo bar>>)
       /// Lexes as BeginCommand Identifier Text EndCommand
-      ['BeginCommand Identifier Text EndCommand', '$$ = new yy.CommandNode($2 + " " + $3);'],
+      // ['BeginCommand Text EndCommand', '$$ = new yy.CommandNode($2);'],
+      ['BeginCommand CmdIdentifier Text EndCommand', '$$ = new yy.CommandNode($2 + " " + $3);'],
     ],
 
     arguments: [

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -109,11 +109,7 @@ const grammar = {
     ],
 
     command: [
-      ['BeginCommand CmdIdentifier EndCommand', '$$ = new yy.CommandNode($2);'],
-      /// Extremely ugly hack because a command with spaces (e.g. <<foo bar>>)
-      /// Lexes as BeginCommand Identifier Text EndCommand
-      // ['BeginCommand Text EndCommand', '$$ = new yy.CommandNode($2);'],
-      ['BeginCommand CmdIdentifier Text EndCommand', '$$ = new yy.CommandNode($2 + " " + $3);'],
+      ['BeginCommand CommandCall EndCommand', '$$ = new yy.CommandNode($2);'],
     ],
 
     arguments: [

--- a/src/parser/parser.js
+++ b/src/parser/parser.js
@@ -110,9 +110,9 @@ const grammar = {
 
     command: [
       ['BeginCommand Identifier EndCommand', '$$ = new yy.CommandNode($2);'],
-
-      // Extremely ugly hack because a command with spaces (e.g. <<foo bar>>)
-      // Lexes as BeginCommand Identifier Text EndCommand
+      ['BeginCommand CmdIdentifier EndCommand', '$$ = new yy.CommandNode($2);'],
+      /// Extremely ugly hack because a command with spaces (e.g. <<foo bar>>)
+      /// Lexes as BeginCommand Identifier Text EndCommand
       ['BeginCommand Identifier Text EndCommand', '$$ = new yy.CommandNode($2 + " " + $3);'],
     ],
 

--- a/tests/test_lexer.js
+++ b/tests/test_lexer.js
@@ -78,7 +78,7 @@ describe('Lexer', () => {
     lexer.setInput('<<option>>');
 
     expect(lexer.lex()).to.equal('BeginCommand');
-    expect(lexer.lex()).to.equal('Identifier');
+    expect(lexer.lex()).to.equal('CmdIdentifier');
     expect(lexer.lex()).to.equal('EndCommand');
     expect(lexer.lex()).to.equal('EndOfInput');
   });
@@ -143,7 +143,7 @@ describe('Lexer', () => {
     lexer.setInput('<<testcommand>>');
 
     expect(lexer.lex()).to.equal('BeginCommand');
-    expect(lexer.lex()).to.equal('Identifier');
+    expect(lexer.lex()).to.equal('CmdIdentifier');
     expect(lexer.lex()).to.equal('EndCommand');
     expect(lexer.lex()).to.equal('EndOfInput');
   });

--- a/tests/test_lexer.js
+++ b/tests/test_lexer.js
@@ -78,7 +78,7 @@ describe('Lexer', () => {
     lexer.setInput('<<option>>');
 
     expect(lexer.lex()).to.equal('BeginCommand');
-    expect(lexer.lex()).to.equal('CmdIdentifier');
+    expect(lexer.lex()).to.equal('CommandCall');
     expect(lexer.lex()).to.equal('EndCommand');
     expect(lexer.lex()).to.equal('EndOfInput');
   });
@@ -143,7 +143,7 @@ describe('Lexer', () => {
     lexer.setInput('<<testcommand>>');
 
     expect(lexer.lex()).to.equal('BeginCommand');
-    expect(lexer.lex()).to.equal('CmdIdentifier');
+    expect(lexer.lex()).to.equal('CommandCall');
     expect(lexer.lex()).to.equal('EndCommand');
     expect(lexer.lex()).to.equal('EndOfInput');
   });

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -404,7 +404,7 @@ describe('Dialogue', () => {
     expect(commands[2]).to.equal('callFunction()');
 
     expect(run.next().done).to.be.true;
-    expect(commands[3]).to.equal('callFunctionWithParam(\"test\",true,1,12.5)');
+    expect(commands[3]).to.equal('callFunctionWithParam(\"test\",true,1,12.5,[2,3])');
   });
 
   it('Evaluates a function and uses it in a conditional', () => {

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -401,10 +401,10 @@ describe('Dialogue', () => {
     expect(commands[1]).to.equal('command with space');
 
     expect(run.next().done).to.be.true;
-    expect(commands[2]).to.equal('callFunction ()');//<<-- not sure why it adds a SPACE
+    expect(commands[2]).to.equal('callFunction()');
 
     expect(run.next().done).to.be.true;
-    expect(commands[3]).to.equal('callFunctionWithParam (\"test\",true,1,12.5)');//<<-- not sure why it adds a SPACE
+    expect(commands[3]).to.equal('callFunctionWithParam(\"test\",true,1,12.5)');
   });
 
   it('Evaluates a function and uses it in a conditional', () => {

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -389,17 +389,22 @@ describe('Dialogue', () => {
     runner.load(commandAndFunctionYarnData);
     const run = runner.run('BasicCommands');
 
-    let lastCommand = '';
+    let commands= [];
     runner.setCommandHandler((command) => {
-      lastCommand = command;
+      commands.push(command)
     });
-
     let value = run.next().value;
     expect(value).to.deep.equal(new bondage.TextResult('text in between commands', value.data));
-    expect(lastCommand).to.equal('command1');
+    expect(commands[0]).to.equal('command');
 
     expect(run.next().done).to.be.true;
-    expect(lastCommand).to.equal('command with space');
+    expect(commands[1]).to.equal('command with space');
+
+    expect(run.next().done).to.be.true;
+    expect(commands[2]).to.equal('callFunction ()');//<<-- not sure why it adds a SPACE
+
+    expect(run.next().done).to.be.true;
+    expect(commands[3]).to.equal('callFunctionWithParam (\"test\",true,1,12.5)');//<<-- not sure why it adds a SPACE
   });
 
   it('Evaluates a function and uses it in a conditional', () => {

--- a/tests/yarn_files/commandsandfunctions.json
+++ b/tests/yarn_files/commandsandfunctions.json
@@ -2,7 +2,7 @@
 	{
 		"title": "BasicCommands",
 		"tags": "Tag",
-		"body": "<<command1>>text in between commands<<command with space>>",
+		"body": "<<command>>text in between commands<<command with space>> <<callFunction()>> <<callFunctionWithParam(\"test\",true,1,12.5)>>",
 		"position": {
 			"x": 449,
 			"y": 252

--- a/tests/yarn_files/commandsandfunctions.json
+++ b/tests/yarn_files/commandsandfunctions.json
@@ -2,7 +2,7 @@
 	{
 		"title": "BasicCommands",
 		"tags": "Tag",
-		"body": "<<command>>text in between commands<<command with space>> <<callFunction()>> <<callFunctionWithParam(\"test\",true,1,12.5)>>",
+		"body": "<<command>>text in between commands<<command with space>> <<callFunction()>> <<callFunctionWithParam(\"test\",true,1,12.5,[2,3])>>",
 		"position": {
 			"x": 449,
 			"y": 252


### PR DESCRIPTION
Gave this another shot - this time from a different angle. Much thanks to @jhayley for the kind feedback and patience :) 

There is still a quirk seen here:
https://github.com/jhayley/bondage.js/pull/40/files#diff-1f6fe15287b398db63504fd4a8ee9bbbR404
Not sure why bondage.js adds an extra space before the "("