### PR TITLE
 new CommandResult node , also deprecate commandHandler and update test 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,6 @@ const yarnData = JSON.parse(fs.readFileSync('yarnFile.json'));
 
 runner.load(yarnData);
 
-runner.setCommandHandler((command) => {
-  // Called whenever there is a <<command>>, the parameter being the text inside
-});
-
-// Register a function to be called from the dialog
-runner.registerFunction('isEven', (args) => {
-  // Used as <<if isEven($var)>>It is even<<endif>>
-  return args[0] % 2 == 0;
-});
-
 // Loop over the dialogue from the node titled 'Start'
 for (const result of runner.run('Start')) {
   // Do something else with the result
@@ -60,6 +50,9 @@ for (const result of runner.run('Start')) {
 
     // Select based on the option's index in the array (if you don't select an option, the dialog will continue past them)
     result.select(1);
+  } else if (result instanceof bondage.CommandResult) {
+     // If the text was inside <<here>>, it will get returned as a CommandResult string, which you can use in any way you want
+    console.log(result.text);
   }
 }
 

--- a/src/results.js
+++ b/src/results.js
@@ -14,6 +14,18 @@ class TextResult extends Result {
   }
 }
 
+class CommandResult extends Result {
+  /**
+   * Return a command string
+   * @param {string} [text] text to be displayed
+   */
+  constructor(text, yarnNodeData) {
+    super();
+    this.text = text;
+    this.data = yarnNodeData;
+  }
+}
+
 class OptionsResult extends Result {
   /**
    * Create a selectable list of options from the given list of text
@@ -33,4 +45,4 @@ class OptionsResult extends Result {
   }
 }
 
-module.exports = { Result, TextResult, OptionsResult };
+module.exports = { Result, TextResult, CommandResult, OptionsResult };

--- a/src/runner.js
+++ b/src/runner.js
@@ -9,7 +9,6 @@ class Runner {
   constructor() {
     this.yarnNodes = {};
     this.variables = new DefaultVariableStorage();
-    this.commandHandler = null;
     this.functions = {};
     this.visited = {}; // Which nodes have been visited
 
@@ -44,19 +43,6 @@ class Runner {
     }
 
     this.variables = storage;
-  }
-
-  /**
-   * Set the function to be called whenever a command is given
-   * Should accept a single string as a parameter
-   * @param {function} handler
-   */
-  setCommandHandler(handler) {
-    if (typeof handler !== 'function') {
-      throw new Error('Command handler must be a function');
-    }
-
-    this.commandHandler = handler;
   }
 
   registerFunction(name, func) {
@@ -143,10 +129,7 @@ class Runner {
             // Special command, halt execution
             return;
           }
-
-          if (this.commandHandler) {
-            this.commandHandler(node.command);
-          }
+          yield new results.CommandResult(node.command, yarnNodeData);
         }
       }
     }
@@ -332,5 +315,6 @@ class Runner {
 module.exports = {
   Runner,
   TextResult: results.TextResult,
+  CommandResult: results.CommandResult,
   OptionsResult: results.OptionsResult,
 };

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -389,22 +389,16 @@ describe('Dialogue', () => {
     runner.load(commandAndFunctionYarnData);
     const run = runner.run('BasicCommands');
 
-    let commands= [];
-    runner.setCommandHandler((command) => {
-      commands.push(command)
-    });
     let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.CommandResult('command', value.data));
+    value = run.next().value;
     expect(value).to.deep.equal(new bondage.TextResult('text in between commands', value.data));
-    expect(commands[0]).to.equal('command');
-
-    expect(run.next().done).to.be.true;
-    expect(commands[1]).to.equal('command with space');
-
-    expect(run.next().done).to.be.true;
-    expect(commands[2]).to.equal('callFunction()');
-
-    expect(run.next().done).to.be.true;
-    expect(commands[3]).to.equal('callFunctionWithParam(\"test\",true,1,12.5,[2,3])');
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.CommandResult('command with space', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.CommandResult('callFunction()', value.data));
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.CommandResult('callFunctionWithParam(\"test\",true,1,12.5,[2,3])', value.data));
   });
 
   it('Evaluates a function and uses it in a conditional', () => {


### PR DESCRIPTION
This deprecates the command handler approach - where you have to specify a command in advance.

Instead you can put anything inside <<here>> and when it gets called, how it is used is more in control of your side of the code, not bondage.js.

This allows <<commands>> to be used in much broader/flexible ways. It also makes them much easier to understand and control - as they are very much like the TextResult node